### PR TITLE
Change usage to avoid errors + missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ library(cytoviewer)
 
 ```r
 library(cytoviewer)
+library(cytomapper)
 
 # Load example datasets 
 data("pancreasImages")
@@ -62,7 +63,7 @@ data("pancreasMasks")
 data("pancreasSCE")
 
 # Use shiny with images, masks and SCE object
-app <- cytoviewer(image = pancreasImages, masks = pancreasMasks, object = pancreasSCE, img_id = "ImageNb", cell_id = "CellNb")
+app <- cytoviewer(image = pancreasImages, mask = pancreasMasks, object = pancreasSCE, img_id = "ImageNb", cell_id = "CellNb")
 shiny::runApp(app, launch.browser = TRUE)
 ```
 


### PR DESCRIPTION
Just a quick PR for some usage documentation: 

- the example datasets required explicit loading of the `cytomapper` package
- The `mask` argument was incorrectly named as `mask` in the usage example giving an argument error